### PR TITLE
fix: use run_pip for requirement install

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,8 +1,4 @@
-import sys
-
-from launch import is_installed, run
-
+from launch import is_installed, run_pip
 
 if not is_installed("rembg"):
-    python = sys.executable
-    run(f'"{python}" -m pip install rembg', desc="Installing rembg", errdesc="Couldn't install rembg")
+    run_pip("install rembg", "requirements for rembgr")


### PR DESCRIPTION
This extension to successfully install `rembg` when run under [AbdBarho/stable-diffusion-webui-docker](https://github.com/AbdBarho/stable-diffusion-webui-docker) (or [my fork of it](https://github.com/neggles/sd-webui-docker)) - this PR switches out the slightly clunky manual pip call for a call to `run_pip` (which seems to work fine in all the other extensions I use).

I can see one potential problem, it *might* fail to install requirements if `--skip-install` is passed at the command line, but arguably that's how it *should* behave? 🤷